### PR TITLE
added the ability to pass arbitrary arguments to the 'hugo' binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,6 @@ build-conf:
 	cat config.common.toml configs/config.en.toml configs/config.fr.toml > config.toml
 
 run: build
-	./hugow server --theme cca-general --buildDrafts
+	# pass arguments <arg1> and <arg2> to the 'hugo' binary by running: make -- run <arg1> <arg2>
+	# EG: make -- run --buildDrafts -b http://rebrand.cloud.ca
+	./hugow server --theme cca-general $(filter-out $@,$(MAKECMDGOALS))

--- a/themes/cca-general/theme.toml
+++ b/themes/cca-general/theme.toml
@@ -1,7 +1,7 @@
 # theme.toml template for a Hugo theme
 # See https://github.com/gohugoio/hugoThemes#themetoml for an example
 
-name = "Cca General"
+name = "CCA General"
 license = ""
 licenselink = ""
 description = ""


### PR DESCRIPTION
Pass arbitrary arguments to the `hugo` binary by using the following formatting with `make run`.

Example:
```
make -- run --buildDrafts -b http://rebrand.cloud.ca
```