### PR TITLE
Added the ability to update the 'public' directory with 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean-css:
 clean-js:
 	rm -f $(JS_DIR)/$(JS_MIN_FILE)
 
-build: build-css build-js build-conf
+prepare: build-css build-js build-conf
 	cd themes/cca-general && $(MAKE) build
 
 build-css: clean-css
@@ -41,7 +41,12 @@ build-js: clean-js
 build-conf:
 	cat config.common.toml configs/config.en.toml configs/config.fr.toml > config.toml
 
-run: build
+build: prepare
+	# pass arguments <arg1> and <arg2> to the 'hugo' binary by running: make -- build <arg1> <arg2>
+	# EG: make -- build --buildDrafts -b http://rebrand.cloud.ca
+	./hugow --theme cca-general $(filter-out $@,$(MAKECMDGOALS))
+
+run: prepare
 	# pass arguments <arg1> and <arg2> to the 'hugo' binary by running: make -- run <arg1> <arg2>
 	# EG: make -- run --buildDrafts -b http://rebrand.cloud.ca
 	./hugow server --theme cca-general $(filter-out $@,$(MAKECMDGOALS))

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Build Project
 make build
 ```
 
+Pass additional arguments to the `hugo` command by using the following format.
+```
+make -- build --buildDrafts -b http://rebrand.cloud.ca
+```
+
 Run Project
 -----------
 


### PR DESCRIPTION
Because the `hugo server` command does not update the `public` directory and only runs the site out of memory, I was not able to update the `public` directory in order to deploy the current site from that directory.  I change the `make build` to actually build the site and update the `public` directory and the `make run` remains the same.  Now we have a `make prepare` which does what the old `make build` did, as that only prepared the static assets and did not actually build the hugo site.

Let me know if you have any questions.