### PR TITLE
Run 'prepare-conf' target at the end to prevent multiple rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ define clean_js
 	rm -f $(JS_DEST_DIR)/$(JS_DEST_FILE)
 endef
 
-prepare: prepare-css prepare-js prepare-conf prepare-themes
+prepare: prepare-themes prepare-css prepare-js prepare-conf
 
 prepare-css:
 	if [ -d "$(LESS_DIR)" ]; then \
@@ -70,7 +70,7 @@ watch:
 			configs \
 			config.common.toml \
 			themes/cca-general/resources \
-		| xargs -0 -n 1 -I {} make prepare; \
+		| xargs -0 -n 1 -I {} $(MAKE) prepare; \
 	else \
 		while true; do \
 			inotifywait --recursive -e modify,create,delete \
@@ -78,7 +78,7 @@ watch:
 				configs \
 				config.common.toml \
 				themes/cca-general/resources \
-			&& $(MAKE) build; \
+			&& $(MAKE) prepare; \
 		done \
 	fi
 


### PR DESCRIPTION
This is to run `prepare-conf` target at the end of chain of targets in `prepare` and as such it prevents confusion for Hugo when to reload the site. Before this fix, any changes I was making were deployed twice:
1. for config.toml change
2. for resources change

in which the first run was going to cache static resources in browser which in the second run it was trying to update! [race condition!]